### PR TITLE
Be slightly more permissive with project names

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -307,8 +307,9 @@ context of an org.
         following rules:
         \begin{itemize}
             \item Must be between $1$ and $32$ ASCII-encoded characters.
-            \item Must only contain \texttt{a-z}, \texttt{0-9}, `\texttt{-}'
-                and `\texttt{\_}' characters.
+            \item May only contain \texttt{a-z}, \texttt{0-9}, `\texttt{-}',
+                `\texttt{.}' and `\texttt{\_}' characters.
+            \item Must not equal `\texttt{.}' or `\texttt{..}'.
         \end{itemize}
     \item $\field{P}{k}$ represents an existing checkpoint,
     \item $\field{P}{meta}$ is $\leq 128$ bytes long,


### PR DESCRIPTION
We disallow `.` and `..` since these typically mean current/parent
directory, and project names are intended to be used in file systems
as well as displayed after slashes, eg. `<org>/<project-name>`.

Closes #15 